### PR TITLE
added cython

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -324,7 +324,7 @@ where ``<package_name>`` can be replaced with the name of the package, and optio
 
 .. code-block:: posh
 
-    conda install pillow, lxml, jupyter, matplotlib, opencv
+    conda install pillow, lxml, jupyter, matplotlib, opencv, cython
 
 Alternatively, if you don't want to use Anaconda you can install the packages using ``pip``:
 


### PR DESCRIPTION
while executing "make" command in "COCO API installation" in linux ubuntu got  "gcc: error: pycocotools/_mask.c: No such file or directory
"
this thread : https://github.com/cocodataset/cocoapi/issues/141
solved the issue ie: after installing cython