### PR TITLE
double quotes for `pip` package from GitHub

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -357,7 +357,7 @@ As of TensorFlow 2.x, the ``pycocotools`` package is listed as `a dependency of 
         .. code-block:: default
 
             pip install cython
-            pip install git+https://github.com/philferriere/cocoapi.git#subdirectory=PythonAPI
+            pip install "git+https://github.com/philferriere/cocoapi.git#subdirectory=PythonAPI"
 
 
         Note that, according to the `package's instructions <https://github.com/philferriere/cocoapi#this-clones-readme>`_, Visual C++ 2015 build tools must be installed and on your path. If they are not, make sure to install them from `here <https://go.microsoft.com/fwlink/?LinkId=691126>`__.


### PR DESCRIPTION
to avoid
`no matches found: git+https://github.com/philferriere/cocoapi.git#subdirectory=PythonAPI` error