### PR TITLE
Case insensitive search on regex image extensions

### DIFF
--- a/docs/source/scripts/partition_dataset.py
+++ b/docs/source/scripts/partition_dataset.py
@@ -32,7 +32,7 @@ def iterate_dir(source, dest, ratio, copy_xml):
         os.makedirs(test_dir)
 
     images = [f for f in os.listdir(source)
-              if re.search(r'([a-zA-Z0-9\s_\\.\-\(\):])+(.jpg|.jpeg|.png)$', f)]
+              if re.search(r'([a-zA-Z0-9\s_\\.\-\(\):])+(?i)(.jpg|.jpeg|.png)$', f)]
 
     num_images = len(images)
     num_test_images = math.ceil(ratio*num_images)


### PR DESCRIPTION
If our image folder has images with upper case extensions, the script will skip them