### PR TITLE
Update bbox coordinates research in xml to prevent x and y inversion

### DIFF
--- a/docs/source/scripts/generate_tfrecord.py
+++ b/docs/source/scripts/generate_tfrecord.py
@@ -85,10 +85,10 @@ def xml_to_csv(path):
                      int(root.find('size')[0].text),
                      int(root.find('size')[1].text),
                      member[0].text,
-                     int(member[4][0].text),
-                     int(member[4][1].text),
-                     int(member[4][2].text),
-                     int(member[4][3].text)
+                     int(member[4].find('xmin').text),
+                     int(member[4].find('ymin').text),
+                     int(member[4].find('xmax').text),
+                     int(member[4].find('ymax').text)
                      )
             xml_list.append(value)
     column_name = ['filename', 'width', 'height',


### PR DESCRIPTION
When using another annotation tool than labelImg, the coordinates (xmin, ymin, xmax, ymax) can be written in the following order in the xml file : (ymin, xmin, ymax, xmax).
Using their keys instead of their positions in the xml file avoids creating a tfrecord with x and y coordinates reversed in some cases.