### PR TITLE
Update index.rst

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,7 +8,7 @@ TensorFlow 2 Object Detection API tutorial
 
 .. important:: This tutorial is intended for TensorFlow 2.2, which (at the time of writing this tutorial) is the latest stable version of TensorFlow 2.x.
 
-   A version for TensorFlow 1.14 can be found `here <https://tensorflow-object-detection-api-tutorial.readthedocs.io/en/1.14.2/>`_.
+   A version for TensorFlow 1.14 can be found `here <https://tensorflow-object-detection-api-tutorial.readthedocs.io/en/tensorflow-1.14/>`_.
 
 This is a step-by-step tutorial/guide to setting up and using TensorFlow's Object Detection API to perform, namely, object detection in images/video.
 


### PR DESCRIPTION
The earlier link to Tensorflow 1.14 Object Detection API tutorial produces 404 error: https://tensorflow-object-detection-api-tutorial.readthedocs.io/en/1.14.2/. This is an incorrect link.
The correct link is: https://tensorflow-object-detection-api-tutorial.readthedocs.io/en/tensorflow-1.14/